### PR TITLE
[Bug #165595052] Create admin while running script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "NODE_ENV=TEST NODE_ENV=TEST npm run deletetb && NODE_ENV=TEST npm run create && NODE_ENV=TEST nyc --reporter=text --reporter=lcov mocha --timeout 5000  --require @babel/register server/tests/**/*.test.js --exit",
     "dev": "nodemon --require @babel/register server/app",
-    "start": "node --require @babel/register server/app && npm run create && npm run admin",
+    "start": "npm run create && npm run admin && node --require @babel/register server/app",
     "create": "node --require @babel/register server/models/createTables.js",
     "deletetb": "node --require @babel/register server/models/dropTables.js",
     "admin": "node --require @babel/register server/models/admin.js",

--- a/server/models/admin.js
+++ b/server/models/admin.js
@@ -1,7 +1,6 @@
 import bcrypt from 'bcryptjs';
 import pool from './createTables';
 
-console.log('working');
 const admin = {
   firstName: 'Emile',
   lastName: 'Joseph',


### PR DESCRIPTION
#### What does this PR do?
Create admin while running script
#### Accomplished tasks
While I run the start script I create automatically the admin account
#### How can this be manually tested?
1. clone the repo ```https://github.com/Joe-Joseph/Banka-c-3.git```
2. cd inside the folder
3. run ```npm install```
4. run ```npm start```
5. Open Postman
6. test this endpoint ```/api/v2/auth/signup``` on port ```4000```
#### Relevant pivotal tracker story
[#165595052](https://www.pivotaltracker.com/story/show/165595052)